### PR TITLE
Move black and isort configurations in pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,6 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-    args: [
-      --profile, black,
-      --force-sort-within-sections,
-      --line-length, "100",
-      --section-default, THIRDPARTY,
-      src, tests, doc
-    ]
 
 - repo: https://gitlab.com/PyCQA/flake8
   rev: 4.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,10 @@ Source = "https://github.com/pyansys/pypim"
 
 [tool.black]
 line-length = 100
+
+[tool.isort]
+profile = "black"
+src_paths = ["src", "tests", "doc"]
+force_sort_within_sections = "true"
+line_length = 100
+default_section = "THIRDPARTY"


### PR DESCRIPTION
The configuration of these tools is defined in the pre-commit. This leads other tools than pre-commit not to take it in account.

I have black configured to run on save, and it ends up "fighting" against pre-commit due to the difference in line length configuration.

Moving their configuration in pyproject.toml makes all the tools aware of it (including when running black without any argument)