### PR TITLE
Generate the API reference

### DIFF
--- a/doc/source/api/.gitignore
+++ b/doc/source/api/.gitignore
@@ -1,0 +1,1 @@
+_autosummary

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -1,0 +1,14 @@
+=============
+API Reference
+=============
+
+This section gives an overview of the API of PyPIM.
+
+.. currentmodule:: ansys.platform.instancemanagement
+
+.. autosummary::
+    :toctree: _autosummary
+    :nosignatures:
+    
+    Client
+    Definition

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,3 +4,8 @@
    here.
 
 .. include:: ../../README.rst
+
+.. toctree::
+   :hidden:
+   
+   api/index


### PR DESCRIPTION
The documentation was only including the `README.rst`. Add the API reference generated from the python code.