### PR TITLE
Fix field documentation

### DIFF
--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -18,28 +18,39 @@ class Definition:
     """Definition of a product that can be started using the product instance management API.
 
     The definition is a static object describing a product that can be started remotely.
-
-    Args:
-        name (str): Name of the definition.
-            This name is chosen by the server.
-            This name is arbitrary, you should not rely on any static value.
-        product_name (str): Name of the product.
-            This is the name of the product that can be started.
-            For example: "mapdl", or "fluent".
-        product_version (str): Version of the product.
-            This is a string describing the version.
-            When the product is following the Ansys unified installation release process,
-            it should be the 3 letters name, such as "221".
-        available_service_names (Sequence[str]): List of the available service names.
-            If the product exposes a gRPC API, the service will be named "grpc".
-            If the product exposes a REST-like API, the service will be named "http".
-            Custom entries may also be listed.
     """
 
     name: str
+    """Name of the definition.
+
+    This name is chosen by the server and always start with `definitions/`.
+    This name is arbitrary, you should not rely on any static value.
+    """
+
     product_name: str
+    """Name of the product.
+
+    This is the name of the product that can be started.
+    For example: "mapdl", or "fluent".
+    """
+
     product_version: str
+    """Version of the product.
+
+    This is a string describing the version.
+    When the product is following the Ansys unified installation release process,
+    it will be the 3 letters name, such as "221".
+    """
+
     available_service_names: Sequence[str]
+    """List of the available service names.
+
+    If the product exposes a gRPC API, the service will be named "grpc".
+    If the product exposes a REST-like API, the service will be named "http".
+    Custom entries may also be listed, either for sidecar services, or
+    other protocols.
+    """
+
     _stub: ProductInstanceManagerStub = field(default=None, compare=False)
 
     def create_instance(self, timeout: float = None) -> Instance:

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -22,10 +22,38 @@ class Instance:
     """A remote instance of a product."""
 
     definition_name: str
-    name: str = None
-    ready: bool = None
-    status_message: str = None
-    services: Mapping[str, Service] = None
+    """Name of the definition that created this instance."""
+
+    name: str
+    """Name of the instance.
+
+    This name is chosen by the server and always start with "instances/"."""
+
+    ready: bool
+    """Indicates if the instance is ready.
+
+    If `True` then the ``services`` field will contain the list of entrypoints
+    exposed by the instance.
+
+    If `False` then the ``status_message`` field will
+    contain a human readable reason."""
+
+    status_message: str
+    """Status of the instance.
+
+    Human readable message describing the status of the instance.
+    This field is always filled when the instance is not ready."""
+
+    services: Mapping[str, Service]
+    """List of entrypoints exposed by the instance.
+
+    This field is only filled when the instance is ready.
+    If the instance exposes a gRPC API, it will be named `grpc`.
+    If the instance exposes a REST-like API, it will be named `http`.
+
+    It may contain additional entries for custom scenarios such as sidecar services
+    or other protocols."""
+
     _stub: ProductInstanceManagerStub = field(default=None, compare=False)
 
     @staticmethod

--- a/src/ansys/platform/instancemanagement/service.py
+++ b/src/ansys/platform/instancemanagement/service.py
@@ -13,18 +13,27 @@ class Service:
     """An entrypoint to communicate with a remote product.
 
     It can be used to communicate with a remote product.
-
-    Args:
-        uri (str): The URI to reach the service.
-            For gRPC, this is a valid URI, following gRPC name resolution
-            syntax: https://grpc.github.io/grpc/core/md_doc_naming.html
-
-            For HTTP/REST, this is a valid http or https URI. It is the base
-            path of the service API.
     """
 
     uri: str
+    """The URI to reach the service.
+
+    For gRPC, this is a valid URI, following gRPC name resolution
+    syntax: https://grpc.github.io/grpc/core/md_doc_naming.html
+
+    For HTTP/REST, this is a valid http or https URI. It is the base
+    path of the service API.
+    """
+
     headers: Mapping[str, str]
+    """Headers necessary to communicate with the service.
+
+    For a gRPC service, this should be translated into metadata included in
+    every communication with the service.
+
+    For a REST-like service, this sshould be translated into headers included in
+    every communication with the service.
+    """
 
     @staticmethod
     def _from_pim_v1(service: ServiceV1):

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -138,7 +138,12 @@ def test_delete(
     def client():
         stub = ProductInstanceManagerStub(testing_channel)
         instance = Instance(
-            name="instances/hello-world-32", definition_name="definitions/my-def", _stub=stub
+            name="instances/hello-world-32",
+            definition_name="definitions/my-def",
+            ready=False,
+            status_message="loading...",
+            services={},
+            _stub=stub,
         )
         instance.delete()
 


### PR DESCRIPTION
The way I documented the fields did not translate in the documentation.

Move the doc at the field level to be correctly interpreted.

Note: This does not work for fields with default values. I may move away from using dataclass due to such issues.