### PR TITLE
High level call to create instance directly from the client

### DIFF
--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -13,7 +13,7 @@ from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2_grpc 
 from ansys.platform.instancemanagement.instance import Instance
 
 
-@dataclass(frozen=True)
+@dataclass()
 class Definition:
     """Definition of a product that can be started using the product instance management API.
 


### PR DESCRIPTION
Since the most likely workflow we expect from users it just to want to create and delete instances. To avoid them caring about the definitions, and encourage people to let the server pick for them (with ordering by preference), create a shortcut from the client to create instances.

Additional changes:
 - The definitions list is not a dictionary anymore, but a simple list. A mapping by name looked good on paper, but given we definitely don't want any logic to rely on the definition name, using it as key does not achieve anything useful
 - The definition dataclass is not frozen anymore. This prevent mocking. New reason to remove the usage of dataclasses, another false good idea

Fixes #9 