### PR TITLE
Move build_grpc_channel to the instance level

### DIFF
--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -132,6 +132,30 @@ class Instance:
             time.sleep(polling_interval)
             self.update(timeout=timeout_per_request)
 
+    def build_grpc_service(self, service_name: str = "grpc", **kwargs):
+        """Build a gRPC channel to communicate with this instance.
+
+        The instance must be ready before calling this method.
+
+        Args:
+            service_name (str, optional): Custom service name. Defaults to "grpc".
+            kwargs: Will be passed to the grpc channel creation.
+
+        Raises:
+            ValueError: The instance does not support gRPC, or the service name is wrong.
+
+        Returns:
+            grpc.Channel: gRPC channel preconfigured to work with the instance.
+        """
+        if not self.ready:
+            raise RuntimeError(f"The instance is not ready.")
+
+        service = self.services.get(service_name, None)
+        if not service:
+            raise ValueError(f"There is no {service_name} service in the remote instance.")
+
+        return service._build_grpc_channel(**kwargs)
+
     @staticmethod
     def _from_pim_v1(instance: InstanceV1, stub: ProductInstanceManagerStub = None):
         """Create a PyPIM instance from the raw protobuf message.

--- a/src/ansys/platform/instancemanagement/service.py
+++ b/src/ansys/platform/instancemanagement/service.py
@@ -38,7 +38,7 @@ class Service:
     every communication with the service.
     """
 
-    def build_grpc_channel(
+    def _build_grpc_channel(
         self,
         **kwargs,
     ) -> grpc.Channel:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -56,7 +56,7 @@ def test_build_channel(testing_pool, headers):
     # Act
     # Build a grpc channel from the service,
     # and send a message
-    with service.build_grpc_channel() as channel:
+    with service._build_grpc_channel() as channel:
         stub = health_pb2_grpc.HealthStub(channel)
         request = health_pb2.HealthCheckRequest(service="hello world")
         stub.Check(request)


### PR DESCRIPTION
Minor change to the API. Initially, the `build_grpc_channel` was exposed at the `Service` level because this is the object holding the information on how to build the channel. This leads to 

However, from the pypim API point of view, having it at the instance help applying the default "grpc" service name, and better error checking (instance not ready, service that does not exist).

The client code goes from:

```py
pim = pypim.connect()
instance = pim.create_instance(product_name="hello")
instance.wait_for_ready()
service = instance.services["grpc"]
channel = service.build_grpc_channel()
```

to:

```py
pim = pypim.connect()
instance = pim.create_instance(product_name="hello")
instance.wait_for_ready()
channel = instance.build_grpc_channel()
```