### PR TITLE
Rename build_grpc_service to build_grpc_channel

### DIFF
--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -132,7 +132,7 @@ class Instance:
             time.sleep(polling_interval)
             self.update(timeout=timeout_per_request)
 
-    def build_grpc_service(self, service_name: str = "grpc", **kwargs):
+    def build_grpc_channel(self, service_name: str = "grpc", **kwargs):
         """Build a gRPC channel to communicate with this instance.
 
         The instance must be ready before calling this method.

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -274,8 +274,8 @@ def test_create_channel():
     )
 
     # Act: Create two channels
-    channel1 = instance.build_grpc_service()
-    channel2 = instance.build_grpc_service(service_name="other")
+    channel1 = instance.build_grpc_channel()
+    channel2 = instance.build_grpc_channel(service_name="other")
 
     # Assert: The service were called
     main_service._build_grpc_channel.assert_called_once()


### PR DESCRIPTION
The naming chosen in #29 was inconsistent, fix it