### PR TITLE
Test cleanup

### DIFF
--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -13,7 +13,7 @@ from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2_grpc 
 from ansys.platform.instancemanagement.instance import Instance
 
 
-@dataclass()
+@dataclass(frozen=True)
 class Definition:
     """Definition of a product that can be started using the product instance management API.
 

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,40 +1,30 @@
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, call
 
-from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2 import (
-    CreateInstanceRequest,
-    DeleteInstanceRequest,
-    GetInstanceRequest,
-)
-from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2 import (
-    Instance as InstanceV1,
-)
-from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2 import (
-    Service as ServiceV1,
-)
-from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2_grpc import (
-    ProductInstanceManagerStub,
-)
+from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2 as pb2
+from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2_grpc as pb2_grpc
 from google.protobuf.empty_pb2 import Empty
 import grpc
 from grpc import StatusCode
 import grpc_testing
 import pytest
 
-from ansys.platform.instancemanagement import Instance, Service
+import ansys.platform.instancemanagement as pypim
 from conftest import CREATE_INSTANCE_METHOD, DELETE_INSTANCE_METHOD, GET_INSTANCE_METHOD
 
 
 def test_from_pim_v1_proto():
-    instance = Instance._from_pim_v1(
-        InstanceV1(
+    instance = pypim.Instance._from_pim_v1(
+        pb2.Instance(
             name="instances/my-instance",
             definition_name="definitions/my-definition",
             ready=False,
             status_message="not yet ready",
             services={
-                "grpc": ServiceV1(uri="dns://some-service:651", headers={"token": "hello-world"}),
-                "http": ServiceV1(uri="https://some-service:651", headers={"token": "hello-world"}),
+                "grpc": pb2.Service(uri="dns://some-service:651", headers={"token": "hello-world"}),
+                "http": pb2.Service(
+                    uri="https://some-service:651", headers={"token": "hello-world"}
+                ),
             },
         )
     )
@@ -43,62 +33,66 @@ def test_from_pim_v1_proto():
     assert not instance.ready
     assert instance.status_message == "not yet ready"
     assert instance.services == {
-        "grpc": Service(uri="dns://some-service:651", headers={"token": "hello-world"}),
-        "http": Service(uri="https://some-service:651", headers={"token": "hello-world"}),
+        "grpc": pypim.Service(uri="dns://some-service:651", headers={"token": "hello-world"}),
+        "http": pypim.Service(uri="https://some-service:651", headers={"token": "hello-world"}),
     }
 
 
 @pytest.mark.parametrize(
     "invalid_instance",
     [
-        InstanceV1(
+        pb2.Instance(
             name="bad-name",
             definition_name="definitions/my-definition",
             ready=False,
             status_message="not yet ready",
             services={
-                "grpc": ServiceV1(uri="dns://some-service:651", headers={"token": "hello-world"}),
-                "http": ServiceV1(uri="https://some-service:651", headers={"token": "hello-world"}),
+                "grpc": pb2.Service(uri="dns://some-service:651", headers={"token": "hello-world"}),
+                "http": pb2.Service(
+                    uri="https://some-service:651", headers={"token": "hello-world"}
+                ),
             },
         ),
-        InstanceV1(
+        pb2.Instance(
             name="instances/my-instance",
             definition_name=None,
             ready=False,
             status_message="not yet ready",
             services={
-                "grpc": ServiceV1(uri="dns://some-service:651", headers={"token": "hello-world"}),
-                "http": ServiceV1(uri="https://some-service:651", headers={"token": "hello-world"}),
+                "grpc": pb2.Service(uri="dns://some-service:651", headers={"token": "hello-world"}),
+                "http": pb2.Service(
+                    uri="https://some-service:651", headers={"token": "hello-world"}
+                ),
             },
         ),
-        InstanceV1(
+        pb2.Instance(
             name="instances/my-instance",
             definition_name="bad-name",
             ready=False,
             status_message="not yet ready",
             services={
-                "grpc": ServiceV1(uri="dns://some-service:651", headers={"token": "hello-world"}),
-                "http": ServiceV1(uri="https://some-service:651", headers={"token": "hello-world"}),
+                "grpc": pb2.Service(uri="dns://some-service:651", headers={"token": "hello-world"}),
+                "http": pb2.Service(
+                    uri="https://some-service:651", headers={"token": "hello-world"}
+                ),
             },
         ),
     ],
 )
 def test_from_pim_v1_proto_value_error(invalid_instance):
     with pytest.raises(ValueError):
-        Instance._from_pim_v1(invalid_instance)
+        pypim.Instance._from_pim_v1(invalid_instance)
 
 
 def test_create(
     testing_pool: ThreadPoolExecutor,
     testing_channel: grpc_testing.Channel,
 ):
-    def client():
-        stub = ProductInstanceManagerStub(testing_channel)
-        return Instance._create(definition_name="definitions/my-def", stub=stub, timeout=0.1)
-
+    # Arrange
+    # A server returning an instance
     def server():
         _, creation_request, rpc = testing_channel.take_unary_unary(CREATE_INSTANCE_METHOD)
-        response = InstanceV1(
+        response = pb2.Instance(
             name="instances/hello-world-32",
             definition_name="definitions/my-def",
             ready=False,
@@ -108,27 +102,33 @@ def test_create(
         rpc.terminate(response, [], StatusCode.OK, "")
         return creation_request
 
-    client_future = testing_pool.submit(client)
     server_future = testing_pool.submit(server)
 
-    instance = client_future.result()
+    # A client creating an instance
+
+    # Act
+    # Create an instance from the client
+    stub = pb2_grpc.ProductInstanceManagerStub(testing_channel)
+    instance = pypim.Instance._create(definition_name="definitions/my-def", stub=stub, timeout=0.1)
+
+    # Assert
+    # The server got the correct request
     received_creation_request = server_future.result()
-
-    expected_creation_request = CreateInstanceRequest(
-        instance=InstanceV1(definition_name="definitions/my-def")
+    expected_creation_request = pb2.CreateInstanceRequest(
+        instance=pb2.Instance(definition_name="definitions/my-def")
     )
+    assert (
+        received_creation_request == expected_creation_request
+    ), "The request to create an instance did not match what was expected"
 
-    expected_instance = Instance(
+    # The instance was created as expected
+    expected_instance = pypim.Instance(
         name="instances/hello-world-32",
         definition_name="definitions/my-def",
         ready=False,
         status_message="loading...",
         services={},
     )
-
-    assert (
-        received_creation_request == expected_creation_request
-    ), "The request to create an instance did not match what was expected"
     assert (
         instance == expected_instance
     ), "The response to create an instance was not correctly translated"
@@ -138,32 +138,35 @@ def test_delete(
     testing_pool: ThreadPoolExecutor,
     testing_channel: grpc_testing.Channel,
 ):
-    def client():
-        stub = ProductInstanceManagerStub(testing_channel)
-        instance = Instance(
-            name="instances/hello-world-32",
-            definition_name="definitions/my-def",
-            ready=False,
-            status_message="loading...",
-            services={},
-            _stub=stub,
-        )
-        instance.delete()
-
+    # Arrange
+    # A server watching for delete requests
     def server():
         _, deletion_request, rpc = testing_channel.take_unary_unary(DELETE_INSTANCE_METHOD)
         response = Empty()
         rpc.terminate(response, [], StatusCode.OK, "")
         return deletion_request
 
-    client_future = testing_pool.submit(client)
     server_future = testing_pool.submit(server)
 
-    client_future.result()
+    # An instance
+    stub = pb2_grpc.ProductInstanceManagerStub(testing_channel)
+    instance = pypim.Instance(
+        name="instances/hello-world-32",
+        definition_name="definitions/my-def",
+        ready=False,
+        status_message="loading...",
+        services={},
+        _stub=stub,
+    )
+
+    # Act
+    # Delete the instance
+    instance.delete()
+
+    # Assert
+    # The server got the request for the correct instance
     received_deletion_request = server_future.result()
-
-    expected_deletion_request = DeleteInstanceRequest(name="instances/hello-world-32")
-
+    expected_deletion_request = pb2.DeleteInstanceRequest(name="instances/hello-world-32")
     assert (
         received_deletion_request == expected_deletion_request
     ), "The request to create an instance did not match what was expected"
@@ -173,53 +176,60 @@ def test_update(
     testing_pool: ThreadPoolExecutor,
     testing_channel: grpc_testing.Channel,
 ):
-    def client():
-        stub = ProductInstanceManagerStub(testing_channel)
-        instance = Instance(
-            name="instances/hello-world-32",
-            definition_name="definitions/my-def",
-            ready=False,
-            status_message="loading...",
-            services={},
-            _stub=stub,
-        )
-        instance.update(timeout=0.1)
-        return instance
-
+    # Arrange
+    # A server serving a hardcoded instance on GetInstance, and the corresponding pypim instance
     def server():
         _, update_request, rpc = testing_channel.take_unary_unary(GET_INSTANCE_METHOD)
-        response = InstanceV1(
+        response = pb2.Instance(
             name="instances/hello-world-32",
             definition_name="definitions/my-def",
             ready=True,
             status_message=None,
-            services={"http": ServiceV1(uri="http://example.com")},
+            services={"http": pb2.Service(uri="http://example.com")},
         )
         rpc.terminate(response, [], StatusCode.OK, "")
         return update_request
 
-    client_future = testing_pool.submit(client)
     server_future = testing_pool.submit(server)
 
-    updated_instance = client_future.result()
-    received_get_request = server_future.result()
+    stub = pb2_grpc.ProductInstanceManagerStub(testing_channel)
+    instance = pypim.Instance(
+        name="instances/hello-world-32",
+        definition_name="definitions/my-def",
+        ready=False,
+        status_message="loading...",
+        services={},
+        _stub=stub,
+    )
 
-    expected_get_request = GetInstanceRequest(name="instances/hello-world-32")
-    expected_updated_instance = Instance(
+    # Act
+    # Update the instance
+    instance.update(timeout=0.1)
+
+    #  Assert
+    # The server got the correct GetInstance request
+    received_get_request = server_future.result()
+    expected_get_request = pb2.GetInstanceRequest(name="instances/hello-world-32")
+    assert received_get_request == expected_get_request
+
+    # The instance is correctly updated
+    expected_updated_instance = pypim.Instance(
         name="instances/hello-world-32",
         definition_name="definitions/my-def",
         ready=True,
         status_message="",
-        services={"http": Service(uri="http://example.com", headers={})},
+        services={"http": pypim.Service(uri="http://example.com", headers={})},
     )
 
-    assert received_get_request == expected_get_request
-    assert updated_instance == expected_updated_instance
+    assert instance == expected_updated_instance
 
 
 def test_wait_for_ready(testing_channel):
-    stub = ProductInstanceManagerStub(testing_channel)
-    instance = Instance(
+    # Arrange
+    # A mocked instance where the update will not be ready
+    # until three update calls
+    stub = pb2_grpc.ProductInstanceManagerStub(testing_channel)
+    instance = pypim.Instance(
         name="instances/hello-world-32",
         definition_name="definitions/my-def",
         ready=False,
@@ -239,33 +249,39 @@ def test_wait_for_ready(testing_channel):
         if instance.update.call_count > 2:
             instance.ready = True
             instance.status_message = ""
-            instance.services = {"http": Service(uri="http://example.com", headers={})}
+            instance.services = {"http": pb2.Service(uri="http://example.com", headers={})}
 
     instance.update = MagicMock()
     instance.update.side_effect = update_side_effect
+
+    # Act
+    # Wait for the instance to be ready
     instance.wait_for_ready(polling_interval=0.0)
 
+    # Assert
+    # The update was called three times
     instance.update.assert_has_calls([call(timeout=None), call(timeout=None), call(timeout=None)])
+    # And the instance is now ready
     assert instance.ready
     assert instance.status_message == ""
-    assert instance.services == {"http": Service(uri="http://example.com", headers={})}
+    assert instance.services == {"http": pb2.Service(uri="http://example.com", headers={})}
 
 
 def test_create_channel():
     # Arrange
     # Two mocked services
-    main_service = Service(uri="dns:example.com", headers={})
+    main_service = pypim.Service(uri="dns:example.com", headers={})
     main_channel = grpc.insecure_channel("dns:example.com")
     object.__setattr__(main_service, "_build_grpc_channel", MagicMock(return_value=main_channel))
 
-    sidecar_service = Service(uri="dns:ansysapis.com", headers={})
+    sidecar_service = pypim.Service(uri="dns:ansysapis.com", headers={})
     sidecar_channel = grpc.insecure_channel("dns:ansysapis.com")
     object.__setattr__(
         sidecar_service, "_build_grpc_channel", MagicMock(return_value=sidecar_channel)
     )
 
     # An instance containing these services
-    instance = Instance(
+    instance = pypim.Instance(
         name="instances/hello-world-32",
         definition_name="definitions/my-def",
         ready=True,
@@ -277,7 +293,7 @@ def test_create_channel():
     channel1 = instance.build_grpc_channel()
     channel2 = instance.build_grpc_channel(service_name="other")
 
-    # Assert: The service were called
+    # Assert: The services were called
     main_service._build_grpc_channel.assert_called_once()
     sidecar_service._build_grpc_channel.assert_called_once()
     assert channel1 == main_channel

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,17 +1,15 @@
-from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2 import (
-    Service as ServiceV1,
-)
+from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2 as pb2
 import grpc
 import grpc_health.v1.health_pb2 as health_pb2
 import grpc_health.v1.health_pb2_grpc as health_pb2_grpc
 import pytest
 
-from ansys.platform.instancemanagement import Service
+import ansys.platform.instancemanagement as pypim
 
 
 def test_from_pim_v1_proto():
-    service = Service._from_pim_v1(
-        ServiceV1(uri="dns://some-service", headers={"token": "some-token"})
+    service = pypim.Service._from_pim_v1(
+        pb2.Service(uri="dns://some-service", headers={"token": "some-token"})
     )
     assert service.uri == "dns://some-service"
     assert service.headers == {"token": "some-token"}
@@ -20,7 +18,7 @@ def test_from_pim_v1_proto():
 @pytest.mark.parametrize(
     "invalid_service",
     [
-        ServiceV1(
+        pb2.Service(
             uri="",
             headers={"token": "some-token"},
         ),
@@ -28,7 +26,7 @@ def test_from_pim_v1_proto():
 )
 def test_from_pim_v1_proto_value_error(invalid_service):
     with pytest.raises(ValueError):
-        Service._from_pim_v1(invalid_service)
+        pypim.Service._from_pim_v1(invalid_service)
 
 
 @pytest.mark.parametrize("headers", [{}, {"a": "b"}, {"my-token": "value", "identity": "thing"}])
@@ -51,7 +49,7 @@ def test_build_channel(testing_pool, headers):
     port = server.add_insecure_port("127.0.0.1:0")
     server.start()
 
-    service = Service(uri=f"127.0.0.1:{port}", headers=headers)
+    service = pypim.Service(uri=f"127.0.0.1:{port}", headers=headers)
 
     # Act
     # Build a grpc channel from the service,


### PR DESCRIPTION
Cleanup the test from the implementations inconsistencies that occured during dev:

 - Generalize the Arrange/Act/Assert pattern to make the test easier to read
 - Import (aliased) modules instead of classes. No more disambiguation between ServiceV1 and Service for the protobuf and pypim objects, and much shorter import statements
 - In tests with fake servers, only run the server in the background in the "Arrange" part of the test. The client code is now directly in the test code in the "Act" part
 - Refreeze the definition class now that I know how to bypass it for mocking purpose