### PR TITLE
Integrate contextlib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,14 +59,30 @@ Starting MAPDL and communicating with it:
     from ansys.mapdl.core import Mapdl
     
     if pypim.is_configured():
-        pim=pypim.connect()
+        with pypim.connect() as pim:
+            with pim.create_instance(product_name="mapdl", product_version="221") as instance:
+                instance.wait_for_ready()
+                channel = instance.build_grpc_channel(options=[("grpc.max_receive_message_length", 8*1024**2)])
+                mapdl = Mapdl(channel=channel)
+                mapdl.prep7()
+                ...
+
+PyPIM can also be used without using the ``with`` statement for longer term
+usage of the created instance:
+
+.. code-block::
+    
+    import ansys.platform.instancemanagement as pypim
+    from ansys.mapdl.core import Mapdl
+    
+    if pypim.is_configured():
+        pim = pypim.connect()
         instance = pim.create_instance(product_name="mapdl", product_version="221")
-        instance.wait_for_ready()
-        channel = instance.build_grpc_channel(options=[("grpc.max_receive_message_length", 8*1024**2)])
         mapdl = Mapdl(channel=channel)
         mapdl.prep7()
         ...
         instance.delete()
+        pim.close()
 
 Developer Guide
 ===============

--- a/README.rst
+++ b/README.rst
@@ -67,8 +67,7 @@ Starting MAPDL and communicating with it:
                 mapdl.prep7()
                 ...
 
-PyPIM can also be used without using the ``with`` statement for longer term
-usage of the created instance:
+PyPIM can also be used without using the ``with`` statement:
 
 .. code-block::
     

--- a/src/ansys/platform/instancemanagement/__init__.py
+++ b/src/ansys/platform/instancemanagement/__init__.py
@@ -65,6 +65,13 @@ def connect() -> Client:
         >>> import ansys.platform.instancemanagement as pypim
         >>> if pypim.is_configured():
         >>>     client = pypim.connect()
+        >>>     // use the client
+        >>>     client.close()
+
+        >>> import ansys.platform.instancemanagement as pypim
+        >>> if pypim.is_configured():
+        >>>     with pypim.connect() as client:
+        >>>         // use client
     """
     if not is_configured():
         raise RuntimeError("The environment is not configured to use PyPIM.")

--- a/src/ansys/platform/instancemanagement/__init__.py
+++ b/src/ansys/platform/instancemanagement/__init__.py
@@ -71,7 +71,7 @@ def connect() -> Client:
         >>> import ansys.platform.instancemanagement as pypim
         >>> if pypim.is_configured():
         >>>     with pypim.connect() as client:
-        >>>         // use client
+        >>>         # use client
     """
     if not is_configured():
         raise RuntimeError("The environment is not configured to use PyPIM.")

--- a/src/ansys/platform/instancemanagement/__init__.py
+++ b/src/ansys/platform/instancemanagement/__init__.py
@@ -65,7 +65,7 @@ def connect() -> Client:
         >>> import ansys.platform.instancemanagement as pypim
         >>> if pypim.is_configured():
         >>>     client = pypim.connect()
-        >>>     // use the client
+        >>>     # use the client
         >>>     client.close()
 
         >>> import ansys.platform.instancemanagement as pypim

--- a/src/ansys/platform/instancemanagement/client.py
+++ b/src/ansys/platform/instancemanagement/client.py
@@ -1,4 +1,5 @@
 """Client class module."""
+import contextlib
 import json
 import logging
 from typing import Sequence
@@ -19,7 +20,7 @@ from ansys.platform.instancemanagement.interceptor import header_adder_intercept
 logger = logging.getLogger(__name__)
 
 
-class Client:
+class Client(contextlib.AbstractContextManager):
     """High level client object to interact with the product instance management API.
 
     This class exposes the methods of the product instance management API.
@@ -44,6 +45,17 @@ class Client:
         logger.info("Connecting")
         self._channel = channel
         self._stub = ProductInstanceManagerStub(self._channel)
+
+    def __exit__(self, *_):
+        """Close the channel when used in a ``with`` statement."""
+        self._channel.close()
+
+    def close(self):
+        """Close the connection.
+
+        This method is called when using the client in a ``with`` statement.
+        """
+        self._channel.close()
 
     @staticmethod
     def _from_configuration(config_path: str):

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -1,5 +1,7 @@
 """Instance class module."""
 
+
+import contextlib
 from dataclasses import dataclass, field
 import logging
 import time
@@ -23,8 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class Instance:
-    """A remote instance of a product."""
+class Instance(contextlib.AbstractContextManager):
+    """A remote instance of a product.
+
+    This class is a context manager and can be used with the `with` statement to
+    automatically stop the remote instance when the tasks are finished.
+    """
 
     definition_name: str
     """Name of the definition that created this instance."""
@@ -69,6 +75,10 @@ class Instance:
         if self.status_message:
             # TODO: instance specific logger
             logger.info(self.status_message)
+
+    def __exit__(self, *_):
+        """Delete the instance when used in a ``with`` statement."""
+        self.delete()
 
     @staticmethod
     def _create(definition_name: str, stub: ProductInstanceManagerStub, timeout: float = None):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -303,8 +303,8 @@ def test_initialize_from_configuration(testing_pool, tmp_path):
     # Connect the client based on this configuration
     # and run a request
     with patch.dict(os.environ, {"ANSYS_PLATFORM_INSTANCEMANAGEMENT_CONFIG": config_path}):
-        client = pypim.connect()
-        client.definitions(product_name="hello-world", product_version="231")
+        with pypim.connect() as client:
+            client.definitions(product_name="hello-world", product_version="231")
 
     # Assert
     # The server got the request with the intended headers


### PR DESCRIPTION
Fixes #27 

This PR takes advantage of the python context management with two integration:

The client is now a context manager that can be used to close the channel:

```py
with pypim.connect() as pim:
   # do things
```

The instances are now context managers of the remote instance

```py
with pim.create_instance() as instance:
    # do things
```