### PR TITLE
Error management

### DIFF
--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -7,7 +7,8 @@ Use the search feature or click the following links to view API
 documentation.
 
 .. automodule:: ansys.platform.instancemanagement
-    :members:
+    :members: connect, is_configured
+    :ignore-module-all:
 
 .. currentmodule:: ansys.platform.instancemanagement
 
@@ -19,4 +20,8 @@ documentation.
     Definition
     Instance
     Service
-    
+    NotConfiguredError
+    InstanceNotReadyError
+    UnsupportedServiceError
+    InvalidConfigurationError
+    UnsupportedProductError

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/dev", None),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
     # kept here as an example
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     # "numpy": ("https://numpy.org/devdocs", None),

--- a/src/ansys/platform/instancemanagement/__init__.py
+++ b/src/ansys/platform/instancemanagement/__init__.py
@@ -9,8 +9,35 @@ import os
 
 from ansys.platform.instancemanagement.client import Client
 from ansys.platform.instancemanagement.definition import Definition
+from ansys.platform.instancemanagement.exceptions import (
+    InstanceNotFoundError,
+    InstanceNotReadyError,
+    InvalidConfigurationError,
+    NotConfiguredError,
+    RemoteError,
+    UnsupportedProductError,
+    UnsupportedServiceError,
+)
 from ansys.platform.instancemanagement.instance import Instance
 from ansys.platform.instancemanagement.service import Service
+
+__all__ = [
+    "__version__",
+    "CONFIGURATION_PATH_ENVIRONMENT_VARIABLE",
+    "is_configured",
+    "connect",
+    "Client",
+    "Instance",
+    "Service",
+    "Definition",
+    "InstanceNotFoundError",
+    "InvalidConfigurationError",
+    "NotConfiguredError",
+    "RemoteError",
+    "UnsupportedProductError",
+    "InstanceNotReadyError",
+    "UnsupportedServiceError",
+]
 
 __version__ = importlib_metadata.version(__name__.replace(".", "-"))
 
@@ -31,7 +58,7 @@ def is_configured() -> bool:
 def connect() -> Client:
     """Create a PyPIM client based on the environment configuration.
 
-    Before calling this method, ``is_configured()`` should be called to check if
+    Before calling this method, :func:`~is_configured()` should be called to check if
     the environment is configured to use PyPIM.
 
     The environment configuration consists in setting the environment variable
@@ -62,8 +89,11 @@ def connect() -> Client:
 
     Raises
     ------
-    RuntimeError
+    NotConfiguredError
         The environment is not configured to use PyPIM.
+
+    InvalidConfigurationError
+        The configuration is invalid.
 
     Examples
     --------
@@ -79,5 +109,5 @@ def connect() -> Client:
         >>>         # use client
     """
     if not is_configured():
-        raise RuntimeError("The environment is not configured to use PyPIM.")
+        raise NotConfiguredError("The environment is not configured to use PyPIM.")
     return Client._from_configuration(os.environ[CONFIGURATION_PATH_ENVIRONMENT_VARIABLE])

--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -82,24 +82,7 @@ class Definition:
         -------
         Instance
             PyPIM instance definition.
-
-        Raises
-        ------
-        ValueError
-            The raw protobuf message is not valid.
         """
-        if not definition.name or not definition.name.startswith("definitions/"):
-            raise ValueError("A definition name must have a name that starts with `definitions/`.")
-
-        if not definition.product_name:
-            raise ValueError("A definition must have a product name.")
-
-        if not definition.product_version:
-            raise ValueError("A definition must have a product version.")
-
-        if not definition.available_service_names or len(definition.available_service_names) == 0:
-            raise ValueError("A definition must have at least one service name.")
-
         return Definition(
             definition.name,
             definition.product_name,

--- a/src/ansys/platform/instancemanagement/exceptions.py
+++ b/src/ansys/platform/instancemanagement/exceptions.py
@@ -1,0 +1,111 @@
+"""Exceptions raised by PyPIM."""
+
+
+import grpc
+
+
+class NotConfiguredError(RuntimeError):
+    """An attempt was made to use PyPIM without the mandatory configuration.
+
+    Consider calling :func:`~is_configured()` before using :func:`~connect()`.
+    """
+
+    pass
+
+
+class InstanceNotReadyError(RuntimeError):
+    """An attempt was made to communicate with an instance that is not yet ready.
+
+    Consider calling :func:`~Instance.wait_for_ready`
+    or checking :attr:`~Instance.ready` before use.
+    """
+
+    instance_name: str
+    """Name of the instance."""
+
+    def __init__(self, instance_name: str) -> None:
+        """Construct the error from the instance name."""
+        self.instance_name = instance_name
+
+        super().__init__(f"{instance_name} is not ready")
+
+
+class UnsupportedServiceError(ValueError):
+    """An attempt was made to communicate with an instance using a service that is not supported."""
+
+    instance_name: str
+    """Name of the instance"""
+
+    service_name: str
+    """Name of the unsupported service"""
+
+    def __init__(self, instance_name: str, service_name: str) -> None:
+        """Construct the error from the instance name and unsupported service."""
+        self.instance_name = instance_name
+        self.service_name = service_name
+
+        super().__init__(f'{instance_name} does not support the service "{service_name}"')
+
+
+class InvalidConfigurationError(RuntimeError):
+    """The PyPIM is configured but the configuration is invalid."""
+
+    configuration_path: str
+    """Path of the invalid configuration."""
+
+    def __init__(self, configuration_path: str, message: str) -> None:
+        """Construct the error from the configuration path and issue."""
+        self.configuration_path = configuration_path
+
+        super().__init__(f"{configuration_path} is invalid: {message}")
+
+
+class UnsupportedProductError(RuntimeError):
+    """The product or version is not supported by the remote server.
+
+    This error is raised when trying to start a product that does not contain
+    any matching definition in the remote server.
+
+    You may try to lift some of the constraints, such as the version constraint.
+    """
+
+    product_name: str
+    """Name of the requested product."""
+
+    product_version: str
+    """(optional) Version of the requested product."""
+
+    def __init__(self, product_name: str, product_version: str) -> None:
+        """Construct the error from the unsupported product and/or version."""
+        self.product_name = product_name
+        self.product_version = product_version
+        if product_version:
+            super().__init__(
+                f"The remote server does not support {self.product_name}\
+in version {self.product_version}."
+            )
+        else:
+            super().__init__(f"The remote server does not support {self.product_name}.")
+
+
+# TODO: We should likely have more specialized versions, but for now
+# let's focus on improving the messages coming from the remote
+class RemoteError(RuntimeError):
+    """A remote request failed.
+
+    When this error is raised, the `__cause__` member contains the original :class:~`grpc.Call`
+    """
+
+    call: grpc.Call
+    """Failed gRPC call."""
+
+    def __init__(self, call: grpc.Call, *args) -> None:
+        """Construct the error from the grpc call/error."""
+        self.call = call
+        super().__init__(*args)
+
+
+class InstanceNotFoundError(RemoteError):
+    """The instance does not exist or was removed."""
+
+    pass

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -18,7 +18,14 @@ from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2 impor
 from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2_grpc import (
     ProductInstanceManagerStub,
 )
+import grpc
 
+from ansys.platform.instancemanagement.exceptions import (
+    InstanceNotFoundError,
+    InstanceNotReadyError,
+    RemoteError,
+    UnsupportedServiceError,
+)
 from ansys.platform.instancemanagement.service import Service
 
 logger = logging.getLogger(__name__)
@@ -116,9 +123,24 @@ class Instance(contextlib.AbstractContextManager):
         ----------
         timeout : float, optional
             Time in seconds to update the instance. The default is ``None``.
+
+        Raises
+        ------
+        InstanceNotFoundError
+            The instance was deleted.
+
+        RemoteError
+            Unexpected server error.
         """
         request = GetInstanceRequest(name=self.name)
-        instance = self._stub.GetInstance(request, timeout=timeout)
+
+        try:
+            instance = self._stub.GetInstance(request, timeout=timeout)
+        except grpc.RpcError as exc:
+            if exc.code() == grpc.StatusCode.NOT_FOUND:
+                raise InstanceNotFoundError(exc, f"The instance {self.name} was deleted.") from exc
+            raise RemoteError(exc, exc.details()) from exc
+
         self.name = instance.name
         self.definition_name = instance.definition_name
 
@@ -145,6 +167,14 @@ class Instance(contextlib.AbstractContextManager):
             Time to wait between each request in seconds. The default is ``0.5``.
         timeout_per_request : float, optional
             Timeout for each request in seconds. The default is ``None``.
+
+        Raises
+        ------
+        InstanceNotFoundError
+            The instance was deleted.
+
+        RemoteError
+            Unexpected server error.
         """
         self.update(timeout=timeout_per_request)
         while not self.ready:
@@ -170,8 +200,11 @@ class Instance(contextlib.AbstractContextManager):
 
         Raises
         ------
-        ValueError
-            The instance does not support gRPC, or the service name is wrong.
+        InstanceNotReadyError
+            The instance is not yet ready.
+
+        UnsupportedServiceError
+            The instance does not support the service.
 
         Examples
         --------
@@ -191,11 +224,11 @@ class Instance(contextlib.AbstractContextManager):
                 ansys.mapdl Version: 0.61.2
         """
         if not self.ready:
-            raise RuntimeError(f"The instance is not ready.")
+            raise InstanceNotReadyError(self.name)
 
         service = self.services.get(service_name, None)
         if not service:
-            raise ValueError(f"There is no {service_name} service in the remote instance.")
+            raise UnsupportedServiceError(self.name, service_name)
 
         return service._build_grpc_channel(**kwargs)
 
@@ -210,14 +243,6 @@ class Instance(contextlib.AbstractContextManager):
         stub : ProductInstanceManagerStub, optional
             PIM stub.
         """
-        if instance.name and not instance.name.startswith("instances/"):
-            raise ValueError("An instance name must start with ``instances/``.")
-
-        if not instance.definition_name or not instance.definition_name.startswith("definitions/"):
-            raise ValueError(
-                "An instance must have a definition name that starts with `definitions/`."
-            )
-
         return Instance(
             name=instance.name,
             definition_name=instance.definition_name,

--- a/src/ansys/platform/instancemanagement/service.py
+++ b/src/ansys/platform/instancemanagement/service.py
@@ -71,13 +71,5 @@ class Service:
         Service
             The PyPIM service
             PyPIM service definition.
-
-        Raises
-        ------
-        ValueError
-            The raw protobuf message is not valid.
         """
-        if not service.uri:
-            raise ValueError("A service must have an URI.")
-
         return Service(uri=service.uri, headers=service.headers)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -264,6 +264,35 @@ def test_create_instance(testing_channel):
     assert created_instance == instance
 
 
+def test_unsupported_product(
+    testing_channel: grpc_testing.Channel,
+):
+    # Arrange
+    # A client mocking a server not supporting the requested products
+    client = pypim.Client(testing_channel)
+    client.definitions = MagicMock(return_value=[])
+
+    # Act
+    # Attempt to create an unsupported product
+    with pytest.raises(pypim.UnsupportedProductError) as no_product_exception:
+        client.create_instance(product_name="mapdl")
+
+    # Attempt to create an unsupported version
+    with pytest.raises(pypim.UnsupportedProductError) as no_version_exception:
+        client.create_instance(product_name="calculator", product_version="222")
+
+    # Assert: Got an unsupported product exception including the version when
+    # requested
+    assert no_product_exception.value.product_name == "mapdl"
+    assert not no_product_exception.value.product_version
+    assert "mapdl" in str(no_product_exception)
+
+    assert no_version_exception.value.product_name == "calculator"
+    assert no_version_exception.value.product_version == "222"
+    assert "calculator" in str(no_version_exception)
+    assert "222" in str(no_version_exception)
+
+
 def test_initialize_from_configuration(testing_pool, tmp_path):
     # Arrange
     # A basic implementation of PIM able to list definitions
@@ -312,3 +341,74 @@ def test_initialize_from_configuration(testing_pool, tmp_path):
     received_metadata_dict = dict(received_metadata[0])
     assert received_metadata_dict["token"] == "007"
     assert received_metadata_dict["identity"] == "james bond"
+
+
+def test_not_configured():
+    with pytest.raises(pypim.NotConfiguredError):
+        pypim.connect()
+
+
+@pytest.mark.parametrize(
+    ("bad_configuration,message_content"),
+    [
+        (r"""not even the right format""", "json"),
+        (r"""{"version": 2, "pim": "future format"}""", "Unsupported version"),
+        (
+            r"""{"version": 1, "pim": {
+                "headers": {"token": "007","identity": "james bond"},"tls": false}}""",
+            "uri",
+        ),
+        (r"""{"version": 1, "pim": {"uri": "dns:127.0.0.1:5000","tls": false}}""", "headers"),
+        (
+            r"""{"version": 1, "pim": {"uri": "dns:127.0.0.1:5000",
+            "headers": {"token": "007","identity": "james bond"}}}""",
+            "tls",
+        ),
+        (
+            r"""{"version": 1, "pim": {"uri": "dns:127.0.0.1:5000", "tls": true,
+            "headers": {"token": "007","identity": "james bond"}}}""",
+            "not yet supported",
+        ),
+    ],
+)
+def test_bad_configuration(tmp_path, bad_configuration, message_content):
+    config_path = tmp_path / "pim.json"
+    with open(config_path, "w") as f:
+        f.write(bad_configuration)
+
+    with pytest.raises(pypim.InvalidConfigurationError) as exc:
+        pypim.Client._from_configuration(config_path)
+
+    assert message_content in str(exc)
+
+
+def test_list_instance_error(
+    testing_pool: ThreadPoolExecutor,
+    testing_channel: grpc_testing.Channel,
+):
+    # Arrange
+    # A server serving a 500 on ListInstance and ListDefinitions
+    def server():
+        _, update_request, rpc = testing_channel.take_unary_unary(LIST_INSTANCES_METHOD)
+        rpc.terminate(None, [], StatusCode.INTERNAL, "I'm a teapot")
+        _, update_request, rpc = testing_channel.take_unary_unary(LIST_DEFINITIONS_METHOD)
+        rpc.terminate(None, [], StatusCode.INTERNAL, "I'm a teapot")
+        return update_request
+
+    testing_pool.submit(server)
+    client = pypim.Client(testing_channel)
+
+    # Act
+    # List the instances and the definitions
+    with pytest.raises(pypim.RemoteError) as exc1:
+        client.instances()
+    with pytest.raises(pypim.RemoteError) as exc2:
+        client.definitions()
+
+    # Assert
+    # The user got the server message
+    assert "I'm a teapot" in str(exc1)
+    assert "I'm a teapot" in str(exc2)
+    # And can inspect the inner error
+    assert exc1.value.__cause__.code() == grpc.StatusCode.INTERNAL
+    assert exc2.value.__cause__.code() == grpc.StatusCode.INTERNAL

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2 as pb2
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2_grpc as pb2_grpc
-import pytest
 
 import ansys.platform.instancemanagement as pypim
 
@@ -21,40 +20,6 @@ def test_from_pim_v1_proto():
     assert definition.product_name == "my_product"
     assert definition.product_version == "221"
     assert sorted(definition.available_service_names) == sorted(["grpc", "http"])
-
-
-@pytest.mark.parametrize(
-    "invalid_definition",
-    [
-        pb2.Definition(
-            name="invalid",
-            product_name="my_product",
-            product_version="221",
-            available_service_names=["grpc", "http"],
-        ),
-        pb2.Definition(
-            name="definitions/my_def",
-            product_name="my_product",
-            product_version="",
-            available_service_names=["grpc", "http"],
-        ),
-        pb2.Definition(
-            name="definitions/my_def",
-            product_name="my_product",
-            product_version="221",
-            available_service_names=[],
-        ),
-        pb2.Definition(
-            name="definitions/my_def",
-            product_name="",
-            product_version="221",
-            available_service_names=[],
-        ),
-    ],
-)
-def test_from_pim_v1_proto_value_error(invalid_definition):
-    with pytest.raises(ValueError):
-        pypim.Definition._from_pim_v1(invalid_definition)
 
 
 def test_create_instance(testing_channel):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -15,20 +15,6 @@ def test_from_pim_v1_proto():
     assert service.headers == {"token": "some-token"}
 
 
-@pytest.mark.parametrize(
-    "invalid_service",
-    [
-        pb2.Service(
-            uri="",
-            headers={"token": "some-token"},
-        ),
-    ],
-)
-def test_from_pim_v1_proto_value_error(invalid_service):
-    with pytest.raises(ValueError):
-        pypim.Service._from_pim_v1(invalid_service)
-
-
 @pytest.mark.parametrize("headers", [{}, {"a": "b"}, {"my-token": "value", "identity": "thing"}])
 def test_build_channel(testing_pool, headers):
     # Arrange

--- a/tox.ini
+++ b/tox.ini
@@ -43,4 +43,5 @@ description = Check if documentation generates properly
 deps =
     -r{toxinidir}/requirements/requirements_doc.txt
 commands =
+    /bin/rm -rf {toxinidir}/doc/source/api/_autosummary
     sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxworkdir}/doc_out" --color -vW -bhtml


### PR DESCRIPTION
Put the basis for error management:

 - PyPIM now raises its own errors deriving from ValueError and RuntimeError
 - All the grpc raise a "RemoteError" instead of the raw grpc error. This is currently low value as there is only one specialized version of it, but we can expand on it in a non api breaking way: Users can write "catch RemoteError as e", then even when we add more derived version this code will behave the same.
 - Remove the protobuf message validation. This is testing the server behavior, not using the server.

Additional changes:

 - Add the "__all__" entry in __init__.py. It's a bit unclear for me, but for some kind of imports, flake8 complains that they are unused if not put in the "__all__" which is kind of defining what is the formal public API of the module.
 - Battle against doc gen to keep all without clash

Fixes #17