### PR TITLE
Add a tox environment for the current python version

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -31,11 +31,11 @@ Test automation relies on `tox`_. `tox`_ can be installed with:
 
 
 Tests are entirely based on mocks and do not require any external software. Run
-the tests with the following code, where ``py38`` represents your Python version:
+the tests with the following code:
 
 .. code-block::
     
-    tox -e py38
+    tox -e py
 
 .. _`tox`: https://tox.wiki/en/latest/install.html#installation-with-pip
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py: python3
     {style,reformat,doc,build}: python3
 setenv =
     PYTHONUNBUFFERED = yes


### PR DESCRIPTION
Add a "py" tox environment, just like the default https://tox.wiki/en/latest/config.html#tox-environments

This enables users to run the tests with "tox -e py" without knowing their python version (tox -e py38, ...)