### PR TITLE
Remove the usage of dataclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ cython_debug/
 #.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+
+# VSCode
+.vscode

--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -1,6 +1,5 @@
 """Definition class module."""
 
-from dataclasses import dataclass, field
 from typing import Sequence
 
 from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2 import (
@@ -13,44 +12,82 @@ from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2_grpc 
 from ansys.platform.instancemanagement.instance import Instance
 
 
-@dataclass(frozen=True)
 class Definition:
     """Provides a definition of a product that can be started using the PIM API.
 
     The definition is a static object describing a product that can be started remotely.
     """
 
-    name: str
-    """Name of the definition.
+    _name: str
+    _product_name: str
+    _product_version: str
+    _available_service_names: Sequence[str]
+    _stub: ProductInstanceManagerStub = None
 
-    This name is chosen by the server and always start with `definitions/`.
-    This name is arbitrary. You should not rely on any static value.
-    """
+    @property
+    def name(self) -> str:
+        """Name of the definition.
 
-    product_name: str
-    """Name of the product.
+        This name is chosen by the server and always start with `definitions/`.
+        This name is arbitrary. You should not rely on any static value.
+        """
+        return self._name
 
-    This is the name of the product that can be started (for example, ``"mapdl"`` or ``"fluent"``).
-    """
+    @property
+    def product_name(self) -> str:
+        """Name of the product.
 
-    product_version: str
-    """Version of the product.
+        This is the name of the product that can be started (for example, ``"mapdl"`` or
+        ``"fluent"``).
+        """
+        return self._product_name
 
-    This is a string describing the version.
-    When the product is following the release process for the Ansys unified installation,
-    the version is three numbers, such as "221".
-    """
+    @property
+    def product_version(self) -> str:
+        """Version of the product.
 
-    available_service_names: Sequence[str]
-    """List of the available service names.
+        This is a string describing the version.
+        When the product is following the release process for the Ansys unified installation,
+        the version is three numbers, such as "221".
+        """
+        return self._product_version
 
-    If the product exposes a gRPC API, the service will be named "grpc".
-    If the product exposes a REST-like API, the service will be named "http".
-    Custom entries might also be listed, either for sidecar services or
-    other protocols.
-    """
+    @property
+    def available_service_names(self) -> Sequence[str]:
+        """List of the available service names.
 
-    _stub: ProductInstanceManagerStub = field(default=None, compare=False)
+        If the product exposes a gRPC API, the service will be named "grpc".
+        If the product exposes a REST-like API, the service will be named "http".
+        Custom entries might also be listed, either for sidecar services or
+        other protocols.
+        """
+        return self._available_service_names
+
+    def __init__(
+        self,
+        name: str,
+        product_name: str,
+        product_version: str,
+        available_service_names: Sequence[str],
+        stub: ProductInstanceManagerStub = None,
+    ):
+        """Create a Definition."""
+        self._name = name
+        self._product_name = product_name
+        self._product_version = product_version
+        self._available_service_names = available_service_names
+        self._stub = stub
+
+    def __eq__(self, obj):
+        """Test for equality."""
+        if not isinstance(obj, Definition):
+            return False
+        return (
+            self.name == obj.name
+            and self.product_name == obj.product_name
+            and self.product_version == obj.product_version
+            and self.available_service_names == obj.available_service_names
+        )
 
     def create_instance(self, timeout: float = None) -> Instance:
         """Create a product instance from this definition.

--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -48,7 +48,7 @@ class Definition:
 
         This is a string describing the version.
         When the product is following the release process for the Ansys unified installation,
-        the version is three numbers, such as "221".
+        the version is three digits, such as "221".
         """
         return self._product_version
 

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -62,10 +62,10 @@ class Instance(contextlib.AbstractContextManager):
     def ready(self) -> bool:
         """Whether the instance is ready.
 
-        If ``True``, the ``services`` field contains the list of entry points
+        If ``True``, the ``services`` property contains the list of entry points
         exposed by the instance.
 
-        If ``False``, the ``status_message`` field contains a human-readable
+        If ``False``, the ``status_message`` property contains a human-readable
         reason.
         """
         return self._ready
@@ -75,7 +75,7 @@ class Instance(contextlib.AbstractContextManager):
         """Status of the instance.
 
         Human-readable message describing the status of the instance.
-        This field is always filled when the instance is not ready.
+        This property is always filled when the instance is not ready.
         """
         return self._status_message
 
@@ -83,7 +83,7 @@ class Instance(contextlib.AbstractContextManager):
     def services(self) -> Mapping[str, Service]:
         """List of entry points exposed by the instance.
 
-        This field is only filled when the instance is ready.
+        This property is only filled when the instance is ready.
         If the instance exposes a gRPC API, it is named ``grpc``.
         If the instance exposes a REST-like API, it is named ``http``.
 

--- a/src/ansys/platform/instancemanagement/service.py
+++ b/src/ansys/platform/instancemanagement/service.py
@@ -1,6 +1,5 @@
 """Service class module."""
 
-from dataclasses import dataclass
 from typing import Mapping
 
 from ansys.api.platform.instancemanagement.v1.product_instance_manager_pb2 import (
@@ -11,29 +10,44 @@ import grpc
 from ansys.platform.instancemanagement.interceptor import header_adder_interceptor
 
 
-@dataclass(frozen=True)
 class Service:
     """An entry point to communicate with a remote product."""
 
-    uri: str
-    """URI to reach the service.
+    _uri: str
+    _headers: Mapping[str, str]
 
-    For gRPC, this is a valid URI, following gRPC-name resolution
-    syntax: https://grpc.github.io/grpc/core/md_doc_naming.html
+    @property
+    def uri(self) -> str:
+        """URI to reach the service.
 
-    For HTTP/REST, this is a valid http or https URI. It is the base
-    path of the service API.
-    """
+        For gRPC, this is a valid URI, following gRPC-name resolution
+        syntax: https://grpc.github.io/grpc/core/md_doc_naming.html
 
-    headers: Mapping[str, str]
-    """Headers necessary to communicate with the service.
+        For HTTP/REST, this is a valid http or https URI. It is the base
+        path of the service API.
+        """
+        return self._uri
 
-    For a gRPC service, this should be translated into metadata included in
-    every communication with the service.
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """Headers necessary to communicate with the service.
 
-    For a REST-like service, this should be translated into headers included in
-    every communication with the service.
-    """
+        For a gRPC service, this should be translated into metadata included in
+        every communication with the service.
+
+        For a REST-like service, this should be translated into headers included in
+        every communication with the service.
+        """
+        return self._headers
+
+    def __init__(self, uri: str, headers: Mapping[str, str]):
+        """Create a Service."""
+        self._uri = uri
+        self._headers = headers
+
+    def __eq__(self, obj):
+        """Test for equality."""
+        return isinstance(obj, Service) and obj.headers == self.headers and obj.uri == self.uri
 
     def _build_grpc_channel(
         self,

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -42,7 +42,7 @@ def test_create_instance(testing_channel):
             product_name="my_product",
             product_version="221",
             available_service_names=["grpc", "http"],
-            _stub=stub,
+            stub=stub,
         )
 
         # Act

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -110,7 +110,7 @@ def test_delete(
         ready=False,
         status_message="loading...",
         services={},
-        _stub=stub,
+        stub=stub,
     )
 
     # Act
@@ -211,7 +211,7 @@ def test_update(
         ready=False,
         status_message="loading...",
         services={},
-        _stub=stub,
+        stub=stub,
     )
 
     # Act
@@ -257,7 +257,7 @@ def test_update_notfound(
         ready=False,
         status_message="Loading...",
         services={},
-        _stub=stub,
+        stub=stub,
     )
 
     # Act
@@ -294,7 +294,7 @@ def test_update_error(
         ready=False,
         status_message="Loading...",
         services={},
-        _stub=stub,
+        stub=stub,
     )
 
     # Act
@@ -320,21 +320,21 @@ def test_wait_for_ready(testing_channel):
         ready=False,
         status_message="Creating...",
         services={},
-        _stub=stub,
+        stub=stub,
     )
 
     def update_side_effect(timeout):
         timeout  # unused
         if instance.update.call_count == 0 or instance.update.call_count == 1:
-            instance.ready = False
-            instance.status_message = "Loading..."
+            instance._ready = False
+            instance._status_message = "Loading..."
         if instance.update.call_count == 2:
-            instance.ready = False
-            instance.status_message = "Routing..."
+            instance._ready = False
+            instance._status_message = "Routing..."
         if instance.update.call_count > 2:
-            instance.ready = True
-            instance.status_message = ""
-            instance.services = {"http": pb2.Service(uri="http://example.com", headers={})}
+            instance._ready = True
+            instance._status_message = ""
+            instance._services = {"http": pb2.Service(uri="http://example.com", headers={})}
 
     instance.update = MagicMock()
     instance.update.side_effect = update_side_effect


### PR DESCRIPTION
The dataclass pattern looked great for removing the boilerplate of __init__, __eq__ around attributes.

However, in the end there was multiple issues in our context:
 - Does not play nicely with sphinx. As soon as we try to customize an attribute using "field()", it would hide it from the doc (or create errors)
 - Does not allow for private setters, classes and attributes are either writable or read-only. This does not play well in Instance for example, where we want it read-only for the user, but still updated when calling "update()".
 - Does not play well with private attributes like the _stub: the constructor argument itself is "_stub".

This PR switches to a more usual way with private attribute and their setters.