### PR TITLE
Automatically include the cname in the documentaion

### DIFF
--- a/doc/source/CNAME
+++ b/doc/source/CNAME
@@ -1,0 +1,1 @@
+pypim.docs.pyansys.com

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -77,6 +77,9 @@ numpydoc_validation_checks = {
 # static path
 html_static_path = ["_static"]
 
+# Include the cname in the generated documentation.
+html_extra_path = ["CNAME"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
The pyansys documentation process relies on a CNAME file to allocate the URL, but th documentation process was erasing it at each release.

This PR automatically include it in the documentation output.

Fixes #35 