### PR TITLE
Replace raw mock creations with create_autospec

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch, create_autospec
 
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2 as pb2
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2_grpc as pb2_grpc
@@ -331,9 +331,11 @@ def test_create_instance(testing_channel):
         status_message="loading...",
         services={},
     )
-    object.__setattr__(definitions[0], "create_instance", MagicMock(return_value=instance))
-    object.__setattr__(definitions[1], "create_instance", MagicMock())
-    client.list_definitions = MagicMock(return_value=definitions)
+    definitions[0].create_instance = create_autospec(
+        definitions[0].create_instance, return_value=instance
+    )
+    definitions[1].create_instance = create_autospec(definitions[1].create_instance)
+    client.list_definitions = create_autospec(client.list_definitions, return_value=definitions)
 
     # Act
     created_instance = client.create_instance(
@@ -342,6 +344,7 @@ def test_create_instance(testing_channel):
 
     # Assert
     # The method created an instance from the first definition
+    client.list_definitions.assert_called()
     client.list_definitions.assert_called_once_with(
         product_name="definitions/the-good-one", product_version=None, timeout=0.32
     )
@@ -356,7 +359,7 @@ def test_unsupported_product(
     # Arrange
     # A client mocking a server not supporting the requested products
     client = pypim.Client(testing_channel)
-    client.list_definitions = MagicMock(return_value=[])
+    client.list_definitions = create_autospec(client.list_definitions, return_value=[])
 
     # Act
     # Attempt to create an unsupported product

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 import os
-from unittest.mock import patch, create_autospec
+from unittest.mock import create_autospec, patch
 
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2 as pb2
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2_grpc as pb2_grpc

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import MagicMock, call
+from unittest.mock import create_autospec, call
 
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2 as pb2
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2_grpc as pb2_grpc
@@ -336,7 +336,7 @@ def test_wait_for_ready(testing_channel):
             instance._status_message = ""
             instance._services = {"http": pb2.Service(uri="http://example.com", headers={})}
 
-    instance.update = MagicMock()
+    instance.update = create_autospec(instance.update)
     instance.update.side_effect = update_side_effect
 
     # Act
@@ -357,12 +357,14 @@ def test_create_channel():
     # Two mocked services
     main_service = pypim.Service(uri="dns:example.com", headers={})
     main_channel = grpc.insecure_channel("dns:example.com")
-    object.__setattr__(main_service, "_build_grpc_channel", MagicMock(return_value=main_channel))
+    main_service._build_grpc_channel = create_autospec(
+        main_service._build_grpc_channel, return_value=main_channel
+    )
 
     sidecar_service = pypim.Service(uri="dns:ansysapis.com", headers={})
     sidecar_channel = grpc.insecure_channel("dns:ansysapis.com")
-    object.__setattr__(
-        sidecar_service, "_build_grpc_channel", MagicMock(return_value=sidecar_channel)
+    sidecar_service._build_grpc_channel = create_autospec(
+        sidecar_service._build_grpc_channel, return_value=sidecar_channel
     )
 
     # An instance containing these services

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import create_autospec, call
+from unittest.mock import call, create_autospec
 
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2 as pb2
 from ansys.api.platform.instancemanagement.v1 import product_instance_manager_pb2_grpc as pb2_grpc


### PR DESCRIPTION
When using directly MagicMock, the mock does not know about the signature of the mocked function. It means that unless the assertion is done with "assert_called_with", then the code may be passing invalid arguments, undetected by the mock.

Using create_autospec fixes this, making the mock have the same API as the original function.

create_autospec have some caveats when used for mocking whole class, but we are only mocking functions.