### PR TITLE
Fix __str__ representation

### DIFF
--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -89,12 +89,12 @@ class Definition:
             and self.available_service_names == obj.available_service_names
         )
 
-    def __str__(self):
-        """Human readable description."""
+    def __repr__(self):
+        """Python-callable description."""
         return (
-            f"Definition(name: {self.name}, product_name: {self.product_name},"
-            f" product_version: {self.product_version}, available_services_names:"
-            f" {self.available_service_names})"
+            f"Definition(name={repr(self.name)}, product_name={repr(self.product_name)},"
+            f" product_version={repr(self.product_version)}, available_service_names="
+            f"{repr(self.available_service_names)})"
         )
 
     def create_instance(self, timeout: float = None) -> Instance:

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -128,11 +128,12 @@ class Instance(contextlib.AbstractContextManager):
             and obj.services == self.services
         )
 
-    def __str__(self):
-        """Human readable description."""
+    def __repr__(self):
+        """Python callable representation."""
         return (
-            f"Instance(name: {self.name}, definition: {self.definition_name}, ready: {self.ready},"
-            f" status_message: {self.status_message}, services: {self.services})"
+            f"Instance(name={repr(self.name)}, definition_name={repr(self.definition_name)},"
+            f" ready={repr(self.ready)}, status_message={repr(self.status_message)},"
+            f" services={repr(self.services)})"
         )
 
     @staticmethod

--- a/src/ansys/platform/instancemanagement/service.py
+++ b/src/ansys/platform/instancemanagement/service.py
@@ -49,9 +49,9 @@ class Service:
         """Test for equality."""
         return isinstance(obj, Service) and obj.headers == self.headers and obj.uri == self.uri
 
-    def __str__(self):
-        """Human readable description."""
-        return f"Service(uri: {self.uri}, headers: {self.headers})"
+    def __repr__(self):
+        """Python callable representation."""
+        return f"Service(uri={repr(self.uri)}, headers={repr(self.headers)})"
 
     def _build_grpc_channel(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -438,7 +438,7 @@ def test_not_configured():
 
 
 @pytest.mark.parametrize(
-    ("bad_configuration,message_content"),
+    "bad_configuration,message_content",
     [
         (r"""not even the right format""", "json"),
         (r"""{"version": 2, "pim": "future format"}""", "Unsupported version"),

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -69,3 +69,16 @@ def test_str():
     assert "my_product" in definition_str
     assert "221" in definition_str
     assert "grpc" in definition_str
+
+
+def test_repr():
+    from ansys.platform.instancemanagement import Definition  # noqa
+
+    definition = pypim.Definition(
+        name="definitions/my_def",
+        product_name="my_product",
+        product_version="221",
+        available_service_names=["grpc"],
+    )
+
+    assert definition == eval(repr(definition))

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -417,7 +417,7 @@ def test_create_channel_not_supported():
         ready=True,
         status_message=None,
         services={
-            "http": "http://example.com",
+            "http": pypim.Service(uri="http://example.com", headers={}),
         },
     )
 
@@ -440,7 +440,7 @@ def test_str():
             ready=False,
             status_message="Loading.",
             services={
-                "my-http": "http://example.com",
+                "my-http": pypim.Service(uri="http://example.com", headers={}),
             },
         )
     )
@@ -450,3 +450,19 @@ def test_str():
     assert "Loading." in instance_str
     assert "my-http" in instance_str
     assert "http://example.com" in instance_str
+
+
+def test_repr():
+    from ansys.platform.instancemanagement import Instance, Service  # noqa
+
+    instance = pypim.Instance(
+        name="instances/hello-world-32",
+        definition_name="definitions/my-def",
+        ready=False,
+        status_message="Loading.",
+        services={
+            "my-http": pypim.Service(uri="http://example.com", headers={}),
+        },
+    )
+    instance_repr = eval(repr(instance))
+    assert instance == instance_repr


### PR DESCRIPTION
#54 had a overlook: for some reason, in python, calling `print(some_obj)` is using `some_obj.__str__`, but calling `print([some_obj])` is using `some_obj.__repr__`. This leads instances not printing correctly their services. This was overlooked by the test as they were not assigning dictionaries of services, but dictionaries of strings.

This PR fixes this issue by implementing __repr__ instead of __str__. By default, __str__ is calling __repr__ so I have not kept a separate implementation.