### PR TITLE
doc/General documentation edits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,10 +131,10 @@ Integration
 -----------
 
 PyPIM can be integrated in PyAnsys libraries to transparently switch to a remote
-instance in a suitable environment. This process is described in the integration
-guide.
+instance in a suitable environment. This process is described in the documentation's
+integration topic.
 
-For example, starting MAPDL with PyPIM is actually as simple as:
+For example, starting MAPDL with PyPIM is as simple as:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ Integration
 
 PyPIM can be integrated in PyAnsys libraries to transparently switch to a remote
 instance in a suitable environment. This process is described in the documentation's
-integration topic.
+:ref:`integration topic`<integration>.
 
 For example, starting MAPDL with PyPIM is as simple as:
 

--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ Integration
 -----------
 
 PyPIM can be integrated in PyAnsys libraries to transparently switch to a remote
-instance in a suitable environment. This process is described in the documentation's
+instance in a suitable environment. This process is described in the
 :ref:`integration` topic.
 
 For example, starting MAPDL with PyPIM is as simple as:

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ Integration
 
 PyPIM can be integrated in PyAnsys libraries to transparently switch to a remote
 instance in a suitable environment. This process is described in the documentation's
-:ref:`integration topic`<integration>.
+:ref:`integration` topic.
 
 For example, starting MAPDL with PyPIM is as simple as:
 

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ Integration
 
 PyPIM can be integrated in PyAnsys libraries to transparently switch to a remote
 instance in a suitable environment. This process is described in the
-:ref:`integration` topic.
+integration topic.
 
 For example, starting MAPDL with PyPIM is as simple as:
 

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -2,9 +2,8 @@
 API Reference
 =============
 
-Welcome to PyPIM API documentation.
-Use the search feature or click the following links to view API
-documentation.
+Welcome to PyPIM API documentation. Use the search feature or
+click the links in the navigation pane to view API documentation.
 
 .. automodule:: ansys.platform.instancemanagement
     :members: connect, is_configured

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -23,7 +23,7 @@ Run this code to clone and install the latest version of PyPIM in development mo
 
 Running Tests
 -------------
-Test automation relies on `tox`_. `tox`_ can be installed with:
+Test automation relies on `tox`_, which can be installed with:
 
 .. code-block::
 
@@ -68,12 +68,11 @@ You can also directly install PyPIM in your current environment with:
 
 Release Process
 ---------------
-
 PyPIM follows the same `branching model`_ as other PyAnsys libraries and the
 same `release procedure`_.
 
 The only notable difference is that the documentation is created with ``tox -e
-doc`` instead of using ``make``.
+doc`` rather than with ``make``.
 
 .. _`branching model`: https://dev.docs.pyansys.com/guidelines/dev_practices.html#branching-model
 .. _`release procedure`: https://dev.docs.pyansys.com/guidelines/dev_practices.html#release-procedures

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,4 +10,4 @@
    
    api/index
    contributing
-   integration_guide
+   integration

--- a/doc/source/integration.rst
+++ b/doc/source/integration.rst
@@ -131,12 +131,12 @@ While the code flow for a non-gRPC product is the same, connection information
 is more specific.
 
 * For a REST-ful product, the base uniform resource identifier (URI) must be
-found under ``instance.services["http"].uri`` and all requests must include the
-headers in ``instance.services["http"].headers``.
+  found under ``instance.services["http"].uri`` and all requests must include the
+  headers in ``instance.services["http"].headers``.
 
 * For other protocols, an agreement between the PIM implementation and the
-client code determines how to pass the required information in a
-dedicated entry in ``.services``.
+  client code determines how to pass the required information in a
+  dedicated entry in ``.services``.
 
 *******
 Testing

--- a/doc/source/integration.rst
+++ b/doc/source/integration.rst
@@ -4,7 +4,7 @@ Integration
 
 .. currentmodule:: ansys.platform.instancemanagement
 
-Even though PyPIM can be used by an application developer, it can also
+While PyPIM can be used by an application developer, it can also
 be used behind the scene by other PyAnsys libraries to manage remote
 instances of the products that they interact with. This enables an application
 developer to write code that works both in an environment configured with PyPIM

--- a/doc/source/integration.rst
+++ b/doc/source/integration.rst
@@ -1,4 +1,8 @@
+.. _integration:
+
 ###########
+
+(part 2 to link from the readme to here)
 Integration
 ###########
 
@@ -61,10 +65,10 @@ without specifying launch information. In other words, PyPIM must be
 the default startup method in an environment that is configured with PyPIM.
 
 To integrate PyPIM correctly, you should use either a generic method such as
-``launch_my_product()`` or a constructor that can start a local process.
+``launch_my_product()`` or a constructor that usually starts a local process.
 
 For example, with PyMAPDL in an environment configured with PyPIM, the following
-code launches PyPIM for use:
+code uses PyPIM:
 
 .. code:: python
 
@@ -72,7 +76,7 @@ code launches PyPIM for use:
 
    mapdl = launch_mapdl()
 
-However, this code does not launch PyPIM for use:
+However, this code does not use PyPIM:
 
 .. code:: python
 
@@ -122,7 +126,7 @@ When stopping the product, ensure that the remote instance is deleted:
 .. note::
    While it is PyPIM's responsibility to clean up any resource and
    process associated with the product, relevant product-specific cleanup
-   is still advised.
+   can still be performed.
 
 Starting a Non-gRPC Product
 ===========================

--- a/doc/source/integration.rst
+++ b/doc/source/integration.rst
@@ -1,8 +1,6 @@
 .. _integration:
 
 ###########
-
-(part 2 to link from the readme to here)
 Integration
 ###########
 

--- a/src/ansys/platform/instancemanagement/__init__.py
+++ b/src/ansys/platform/instancemanagement/__init__.py
@@ -50,7 +50,7 @@ def is_configured() -> bool:
     Returns
     -------
     bool
-       ``True`` when the environment is configured to use PyPIM, ``False`` when it is not.
+        ``True`` when the environment is configured to use PyPIM, ``False`` otherwise.
     """
     return CONFIGURATION_PATH_ENVIRONMENT_VARIABLE in os.environ
 
@@ -63,8 +63,8 @@ def connect() -> Client:
 
     The environment configuration consists in setting the environment variable
     ``ANSYS_PLATFORM_INSTANCEMANAGEMENT_CONFIG`` to the path of the PyPIM
-    configuration file. The configuration file is a simple json file containing
-    the URI of the PIM API and headers required to pass information.
+    configuration file. The configuration file is a simple JSON file containing
+    the URI of the PIM API and the headers required to pass information.
 
     The configuration file format is:
 

--- a/src/ansys/platform/instancemanagement/client.py
+++ b/src/ansys/platform/instancemanagement/client.py
@@ -135,7 +135,7 @@ Consider upgrading ansys-platform-instancemanagement.',
         product_version: str = None,
         timeout: float = None,
     ) -> Sequence[Definition]:
-        """Get a list of supported product definitions.
+        """Get the list of supported product definitions.
 
         Parameters
         ----------

--- a/src/ansys/platform/instancemanagement/client.py
+++ b/src/ansys/platform/instancemanagement/client.py
@@ -88,10 +88,10 @@ class Client(contextlib.AbstractContextManager):
         """
         logger.debug("Initializing from %s", config_path)
 
-        # Note: this configuration should likely become a full-featured object
-        # to be shared across PyPIM class at some point.
-        # The configuration is a plain json file with the settings to create the
-        # grpc channel.
+        # Note: At some point, this configuration is likely to become a
+        # full-featured object to be shared across the PyPIM class.
+        # The configuration is a plain JSON file with the settings for creating
+        # the gRPC channel.
 
         with open(config_path, "r") as f:
             try:
@@ -135,7 +135,7 @@ Consider upgrading ansys-platform-instancemanagement.',
         product_version: str = None,
         timeout: float = None,
     ) -> Sequence[Definition]:
-        """Get the list of supported product definitions.
+        """Get a list of supported product definitions.
 
         Parameters
         ----------
@@ -225,9 +225,9 @@ Consider upgrading ansys-platform-instancemanagement.',
         Parameters
         ----------
         product_name : str
-            Name of the product to start (for example, ``mapdl``).
+            Name of the product to start. For example, ``mapdl``.
         product_version : str, optional
-            Version of the product (for example, ``"222"``). The default is ``None``.
+            Version of the product. For example, ``"222"``. The default is ``None``.
         requests_timeout : float, optional
             Maximum time for each request in seconds. The default is ``None``.
 
@@ -272,7 +272,7 @@ Consider upgrading ansys-platform-instancemanagement.',
         Parameters
         ----------
         name: str
-            Name of the instance to get (for example, ``instances/mapdl-1212``).
+            Name of the instance to get. For example, ``instances/mapdl-1212``.
 
         timeout : float, optional
             Maximum time in seconds for the request. The default is ``None``.

--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -56,8 +56,8 @@ class Definition:
     def available_service_names(self) -> Sequence[str]:
         """List of the available service names.
 
-        If the product exposes a gRPC API, the service name begins with "grpc".
-        If the product exposes a REST-like API, the service name begins with "http".
+        If the product exposes a gRPC API, the service is named "grpc".
+        If the product exposes a REST-like API, the service is named "http".
         Custom entries might also be listed, either for sidecar services or
         other protocols.
         """

--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -37,8 +37,8 @@ class Definition:
     def product_name(self) -> str:
         """Name of the product.
 
-        This is the name of the product that can be started (for example, ``"mapdl"`` or
-        ``"fluent"``).
+        This is the name of the product that can be started. For example, ``"mapdl"`` or
+        ``"fluent"``.
         """
         return self._product_name
 
@@ -56,8 +56,8 @@ class Definition:
     def available_service_names(self) -> Sequence[str]:
         """List of the available service names.
 
-        If the product exposes a gRPC API, the service will be named "grpc".
-        If the product exposes a REST-like API, the service will be named "http".
+        If the product exposes a gRPC API, the service name begins with "grpc".
+        If the product exposes a REST-like API, the service name begins with "http".
         Custom entries might also be listed, either for sidecar services or
         other protocols.
         """

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -85,7 +85,7 @@ class Instance(contextlib.AbstractContextManager):
 
         This property is only filled when the instance is ready.
         If the instance exposes a gRPC API, it is named "grpc".
-        If the instance exposes a REST-like API, the name begins with "http".
+        If the instance exposes a REST-like API, it is named "http".
 
         It may contain additional entries for custom scenarios such as sidecar services
         or other protocols.

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -84,7 +84,7 @@ class Instance(contextlib.AbstractContextManager):
         """List of entry points exposed by the instance.
 
         This property is only filled when the instance is ready.
-        If the instance exposes a gRPC API, the name begins with "grpc".
+        If the instance exposes a gRPC API, it is named "grpc".
         If the instance exposes a REST-like API, the name begins with "http".
 
         It may contain additional entries for custom scenarios such as sidecar services

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -84,8 +84,8 @@ class Instance(contextlib.AbstractContextManager):
         """List of entry points exposed by the instance.
 
         This property is only filled when the instance is ready.
-        If the instance exposes a gRPC API, it is named ``grpc``.
-        If the instance exposes a REST-like API, it is named ``http``.
+        If the instance exposes a gRPC API, the name begins with "grpc".
+        If the instance exposes a REST-like API, the name begins with "http".
 
         It may contain additional entries for custom scenarios such as sidecar services
         or other protocols.
@@ -238,7 +238,7 @@ class Instance(contextlib.AbstractContextManager):
         Parameters
         ----------
         service_name : str, optional
-            Custom service name. The default is ``"grpc"``.
+            Custom service name. The name begins with "grpc".
         kwargs: list
             Named argument to pass to the gRPC channel creation.
 

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -238,7 +238,7 @@ class Instance(contextlib.AbstractContextManager):
         Parameters
         ----------
         service_name : str, optional
-            Custom service name. The name begins with "grpc".
+            Custom service name. The default is "grpc".
         kwargs: list
             Named argument to pass to the gRPC channel creation.
 

--- a/src/ansys/platform/instancemanagement/service.py
+++ b/src/ansys/platform/instancemanagement/service.py
@@ -11,16 +11,16 @@ from ansys.platform.instancemanagement.interceptor import header_adder_intercept
 
 
 class Service:
-    """An entry point to communicate with a remote product."""
+    """Provides an entry point for communicating with a remote product."""
 
     _uri: str
     _headers: Mapping[str, str]
 
     @property
     def uri(self) -> str:
-        """URI to reach the service.
+        """Uniform resource indicator (URI) to reach the service.
 
-        For gRPC, this is a valid URI, following gRPC-name resolution
+        For gRPC, this is a valid URI following gRPC-name resolution
         syntax: https://grpc.github.io/grpc/core/md_doc_naming.html
 
         For HTTP/REST, this is a valid http or https URI. It is the base


### PR DESCRIPTION
@plule-ansys I changed from "Integration Guide" to simply "Integration" because it seemed odd to call something a guide that was a single topic. I wasn't sure if it was possible to link from the README.rst file to the Integration topic since this file is repurposed. If it can be made a link and you know how, I'd love it to work that way. I'll leave some other questions/comments for you in comments. Thanks!