### PR TITLE
Bump ansys-api-platform-instancemanagement version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "importlib-metadata >=4.0",
-    "ansys-api-platform-instancemanagement>=1.0.0b1",
+    "ansys-api-platform-instancemanagement>=1.0.0b3",
 ]
 
 [tool.flit.module]


### PR DESCRIPTION
Bump ansys-api-platform-instancemanagement version to 1.0.0b3.

The previous versions did not correctly tag the upper limit for protobuf, breaking with 4.0