### PR TITLE
Edits based on server assigning instance name

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -12,7 +12,7 @@ before attempting to contribute to PyPIM.
 
 The following contribution information is specific to PyPIM.
 
-Cloning the PyPIM Repository
+Cloning the PyPIM repository
 ----------------------------
 Run this code to clone and install the latest version of PyPIM in development mode:
 
@@ -21,7 +21,7 @@ Run this code to clone and install the latest version of PyPIM in development mo
     git clone https://github.com/pyansys/pypim.git
     cd pypim/
 
-Running Tests
+Running tests
 -------------
 Test automation relies on `tox`_, which can be installed with:
 
@@ -39,7 +39,7 @@ the tests with the following code:
 
 .. _`tox`: https://tox.wiki/en/latest/install.html#installation-with-pip
 
-Building the Documentation
+Building the documentation
 --------------------------
 You can build PyPIM documentation with:
 
@@ -47,7 +47,7 @@ You can build PyPIM documentation with:
     
     tox -e doc
 
-Building the Package
+Building the package
 --------------------
 
 The PyPIM package is built using `flit`.
@@ -66,7 +66,7 @@ You can also directly install PyPIM in your current environment with:
 
 .. _`flit`: https://flit.pypa.io/en/latest/#install
 
-Release Process
+Release process
 ---------------
 PyPIM follows the same `branching model`_ as other PyAnsys libraries and the
 same `release procedure`_.

--- a/doc/source/integration.rst
+++ b/doc/source/integration.rst
@@ -54,7 +54,7 @@ must include the following ``require`` string:
 
 ``"ansys-platform-instancemanagement~=1.0"``
 
-Condition for PyPIM Usage
+Condition for PyPIM usage
 =========================
 
 The condition for using PyPIM transparently is that the user must
@@ -82,7 +82,7 @@ However, this code does not use PyPIM:
 
    mapdl = launch_mapdl(exec_file="/usr/bin/mapdl")
 
-Starting a gRPC Product
+Starting a gRPC product
 =======================
 
 To use PyPIM, the code flow should first check if PyPIM is configured
@@ -126,7 +126,7 @@ When stopping the product, ensure that the remote instance is deleted:
    process associated with the product, relevant product-specific cleanup
    can still be performed.
 
-Starting a Non-gRPC Product
+Starting a Non-gRPC product
 ===========================
 
 While the code flow for a non-gRPC product is the same, connection information

--- a/src/ansys/platform/instancemanagement/client.py
+++ b/src/ansys/platform/instancemanagement/client.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class Client(contextlib.AbstractContextManager):
-    """Provides an high-level client object for interacting with the PIM API.
+    """Provides a high-level client object for interacting with the PIM API.
 
     This class exposes the methods of the PIM API.
     """
@@ -272,7 +272,9 @@ Consider upgrading ansys-platform-instancemanagement.',
         Parameters
         ----------
         name: str
-            Name of the instance to get. For example, ``instances/mapdl-1212``.
+            Name of the instance to get. This name is assigned by the server and
+            always start with ``instances/``. You should not rely on any static value.
+            For example, the name assigned to the instance might be ``instances/mapdl-a25g813``.
 
         timeout : float, optional
             Maximum time in seconds for the request. The default is ``None``.

--- a/src/ansys/platform/instancemanagement/definition.py
+++ b/src/ansys/platform/instancemanagement/definition.py
@@ -28,7 +28,7 @@ class Definition:
     def name(self) -> str:
         """Name of the definition.
 
-        This name is chosen by the server and always start with `definitions/`.
+        This name is assigned by the server and always starts with ``"definitions/"``.
         This name is arbitrary. You should not rely on any static value.
         """
         return self._name
@@ -48,7 +48,7 @@ class Definition:
 
         This is a string describing the version.
         When the product is following the release process for the Ansys unified installation,
-        the version is three digits, such as "221".
+        the version is three digits, such as ``221``.
         """
         return self._product_version
 
@@ -56,8 +56,8 @@ class Definition:
     def available_service_names(self) -> Sequence[str]:
         """List of the available service names.
 
-        If the product exposes a gRPC API, the service is named "grpc".
-        If the product exposes a REST-like API, the service is named "http".
+        If the product exposes a gRPC API, the service is named ``grpc``.
+        If the product exposes a REST-like API, the service is named ``http``.
         Custom entries might also be listed, either for sidecar services or
         other protocols.
         """

--- a/src/ansys/platform/instancemanagement/instance.py
+++ b/src/ansys/platform/instancemanagement/instance.py
@@ -54,7 +54,7 @@ class Instance(contextlib.AbstractContextManager):
     def name(self) -> str:
         """Name of the instance.
 
-        This name is chosen by the server and always start with ``"instances/"``.
+        This name is assigned by the server and always starts with ``"instances/"``.
         """
         return self._name
 
@@ -84,8 +84,8 @@ class Instance(contextlib.AbstractContextManager):
         """List of entry points exposed by the instance.
 
         This property is only filled when the instance is ready.
-        If the instance exposes a gRPC API, it is named "grpc".
-        If the instance exposes a REST-like API, it is named "http".
+        If the instance exposes a gRPC API, it is named ``grpc``.
+        If the instance exposes a REST-like API, it is named ``http``.
 
         It may contain additional entries for custom scenarios such as sidecar services
         or other protocols.
@@ -238,7 +238,7 @@ class Instance(contextlib.AbstractContextManager):
         Parameters
         ----------
         service_name : str, optional
-            Custom service name. The default is "grpc".
+            Custom service name. The default is ``grpc``.
         kwargs: list
             Named argument to pass to the gRPC channel creation.
 

--- a/src/ansys/platform/instancemanagement/service.py
+++ b/src/ansys/platform/instancemanagement/service.py
@@ -21,9 +21,9 @@ class Service:
         """Uniform resource indicator (URI) to reach the service.
 
         For gRPC, this is a valid URI following gRPC-name resolution
-        syntax: https://grpc.github.io/grpc/core/md_doc_naming.html
+        syntax. For example, https://grpc.github.io/grpc/core/md_doc_naming.html.
 
-        For HTTP/REST, this is a valid http or https URI. It is the base
+        For HTTP or REST, this is a valid http or https URI. It is the base
         path of the service API.
         """
         return self._uri


### PR DESCRIPTION
@plule-ansys Back in early June, we discussed changing the get_instance topic so that the name description indicated that the name was assigned by the server. I've finally made the change. I've also read through and done a general edit, which included switching titles to sentence case. We will be implementing Vale in CI checks to use Google style guidelines. Both Google and Microsoft use sentence case for title headings. We've designed to adopt this style. I've changed the titles manually now to save me from having to do it if/when Vale is implemented here. 