### PR TITLE
Allowing dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     ignore:
       # PyPim should not bring additional grpc constraints to other repositories
       - dependency-name: "grpcio"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
The @pyansys/pyansys-core team has recently discovered that dependabot can automatically update GH actions (in a similar fashion to requirements). Proposing implementation in various repositories to keep them up to date.