### PR TITLE
doc: Getting Started & ecosystem links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,5 +164,5 @@ Ansys has an extensive developer ecosystem where you can find assistance for a v
 - `Developer Portal <https://developer.ansys.com/>`: Blog posts, documentation, and guide
 - `Developer Forum <https://discuss.ansys.com/>`: Scripting and usage support for PyAnsys and other Ansys developer tools
 - `Ansys Innovation Space <https://innovationspace.ansys.com/>`: Product support forum and training materials
-- `GitHub <https://github.com/ansys/pymechanical>`: Development support, bug reporting, feature requests, and more.
+- `GitHub <https://github.com/ansys/pypim>`: Development support, bug reporting, feature requests, and more.
 - `Ansys Learning Hub <https://learninghub.ansys.com/>`: Training, courses and learning plans

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Installation
    with ``pip`` and the command line. If they are new to you, you should read
    the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>`
    before proceeding.
-   
+
 The ``ansys-platform-instancemanagement`` package is tested for Python 3.10 through
 Python 3.14 on Windows and Linux.
 

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,13 @@ PyPIM itself is pure Python and relies on `gRPC`_.
 
 Installation
 ------------
+
+.. note::
+   These instructions assume you are familiar
+   with ``pip`` and the command line. If they are new to you, you should read
+   the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>`
+   before proceeding.
+
 The ``ansys-platform-instancemanagement`` package is tested for Python 3.7 through
 Python 3.10 on Windows and Linux.
 
@@ -148,3 +155,14 @@ For example, starting MAPDL with PyPIM is as simple as using this code:
 
     mapdl = launch_mapdl()
 
+
+Ansys developer ecosystem resources
+-----------------------------------
+
+Ansys has an extensive developer ecosystem where you can find assistance for a variety of issues.
+
+- `Developer Portal <https://developer.ansys.com/>`: Blog posts, documentation, and guide
+- `Developer Forum <https://discuss.ansys.com/>`: Scripting and usage support for PyAnsys and other Ansys developer tools
+- `Ansys Innovation Space <https://innovationspace.ansys.com/>`: Product support forum and training materials
+- `GitHub <https://github.com/ansys/pymechanical>`: Development support, bug reporting, feature requests, and more.
+- `Ansys Learning Hub <https://learninghub.ansys.com/>`: Training, courses and learning plans


### PR DESCRIPTION
I am currently working on reviewing and improving PyAnsys Getting Started sections and this work is part of that. It is reasonable to assume new users of PyPIM will be familiar with Python and pip but not guaranteed. So I have added a note + link that makes it clearer what those items are for people that don't know when they first get mentioned in the docs.

In addition, I have added a section on the Ansys wider developer ecosystem as well, including a set of
links to places where users can expect to find resources that may be of assistance, such as the portal, forum AIS, ALH, etc.